### PR TITLE
Implement ingredient price coverage in admin dashboard.

### DIFF
--- a/src/lib/components/ui/card/IngredientCard.svelte
+++ b/src/lib/components/ui/card/IngredientCard.svelte
@@ -1,0 +1,42 @@
+<script lang="ts">
+  export let ingredient: any;
+  export let showAdminActions: boolean = false;
+  import { createEventDispatcher } from 'svelte';
+  const dispatch = createEventDispatcher();
+</script>
+
+<div class="bg-white dark:bg-gray-700 rounded-lg shadow hover:shadow-lg transition-shadow transition-opacity min-h-[100px] p-4 flex flex-col">
+  <div class="flex items-center justify-between">
+    <div class="font-bold text-lg dark:text-white">{ingredient.name}</div>
+    {#if showAdminActions}
+      <div class="flex gap-2">
+        <button class="bg-blue-600 hover:bg-blue-700 text-white px-3 py-1 rounded text-sm dark:bg-blue-900" on:click={() => dispatch('edit', ingredient)}>Rediger ingrediens ✍️</button>
+        <button class="bg-red-600 hover:bg-red-700 text-white px-3 py-1 rounded text-sm dark:bg-red-900" on:click={() => dispatch('delete', ingredient)}>Slett 🗑️</button>
+      </div>
+    {/if}
+  </div>
+  <div class="text-gray-600 dark:text-gray-300 text-sm">
+    EAN: {ingredient.ean || 'N/A'}
+    {#if ingredient.data && ingredient.data.products && ingredient.data.products.length > 0}
+      {#each [ingredient.data.products[0]] as product}
+        <br />
+        Pris: {product.current_price?.price ? Number(product.current_price.price).toFixed(2) + ' kr' : 'N/A'}
+        {#if product.current_price?.unit_price}
+          &nbsp;|&nbsp; Pris per enhet: {Number(product.current_price.unit_price).toFixed(2)} kr/{product.weight_unit || 'enhet'}
+        {/if}
+        {#if product.weight}
+          &nbsp;|&nbsp; Vekt: {product.weight}{product.weight_unit}
+        {/if}
+        {#if product.url}
+          <br />
+          <a href={product.url} target="_blank" rel="noopener noreferrer" class="text-blue-600 hover:underline flex items-center gap-1 mt-1">
+            <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4 inline" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M14 3h7m0 0v7m0-7L10 14m-4 0h7m-7 0v7m0-7L14 3" /></svg>
+            Produktlink
+          </a>
+        {/if}
+      {/each}
+    {:else}
+      <br />Pris: N/A
+    {/if}
+  </div>
+</div> 

--- a/src/lib/components/ui/card/RecipeCard.svelte
+++ b/src/lib/components/ui/card/RecipeCard.svelte
@@ -1,0 +1,19 @@
+<script lang="ts">
+  export let recipe: any;
+  export let showAdminActions: boolean = false;
+  import { createEventDispatcher } from 'svelte';
+  const dispatch = createEventDispatcher();
+</script>
+
+<div class="bg-white dark:bg-gray-700 rounded-lg shadow hover:shadow-lg transition-shadow p-4 flex items-center justify-between cursor-pointer group">
+  <div>
+    <div class="font-bold text-lg group-hover:text-blue-700 transition-colors dark:text-white">{recipe.title}</div>
+    <div class="text-gray-600 dark:text-gray-300">{recipe.subtitle}</div>
+  </div>
+  {#if showAdminActions}
+    <div class="flex gap-2">
+      <button class="bg-blue-600 hover:bg-blue-700 text-white px-4 py-2 rounded dark:bg-blue-900" on:click={() => dispatch('edit', recipe)}>Rediger Oppskrift ✍️</button>
+      <button class="bg-red-600 hover:bg-red-700 text-white px-4 py-2 rounded dark:bg-red-900" on:click={() => dispatch('delete', recipe)}>Slett Oppskrift 🗑️</button>
+    </div>
+  {/if}
+</div> 

--- a/src/lib/components/ui/card/RecipeCard.svelte
+++ b/src/lib/components/ui/card/RecipeCard.svelte
@@ -1,8 +1,58 @@
 <script lang="ts">
   export let recipe: any;
   export let showAdminActions: boolean = false;
+  export let coverage: number | undefined = undefined;
+  export let allIngredients: any[] = [];
   import { createEventDispatcher } from 'svelte';
+  import AddIngredientModal from '$lib/components/ui/modals/AddIngredientModal.svelte';
+  import CoverageModal from '$lib/components/ui/modals/CoverageModal.svelte';
   const dispatch = createEventDispatcher();
+
+  $: coverageColor = coverage === undefined
+    ? ''
+    : coverage >= 90
+      ? 'text-green-600 dark:text-green-400'
+      : coverage >= 50
+        ? 'text-orange-500 dark:text-orange-400'
+        : 'text-red-600 dark:text-red-400';
+
+  let showCoverageModal = false;
+  let showAddModal = false;
+  let addName = '';
+  let addEAN = '';
+  let addError = '';
+
+  $: missingIngredients = recipe.recipeIngredients
+    ? recipe.recipeIngredients.filter((ri: any) => !allIngredients.some(ai => ai.name === ri.name))
+    : [];
+
+  function openCoverageModal() {
+    showCoverageModal = true;
+  }
+  function closeCoverageModal() {
+    showCoverageModal = false;
+  }
+  function openAddModal(name: string) {
+    addName = name;
+    addEAN = '';
+    addError = '';
+    showAddModal = true;
+  }
+  function closeAddModal() {
+    showAddModal = false;
+  }
+  function handleAddIngredient({ detail }) {
+    if (!detail.name || !detail.ean) {
+      addError = 'Navn og EAN er påkrevd';
+      return;
+    }
+    addError = '';
+    dispatch('addIngredient', { name: detail.name, ean: detail.ean });
+    // Don't close modal, let parent update allIngredients and thus missingIngredients
+  }
+  function handleCoverageAdd({ detail }) {
+    openAddModal(detail.name);
+  }
 </script>
 
 <div class="bg-white dark:bg-gray-700 rounded-lg shadow hover:shadow-lg transition-shadow p-4 flex items-center justify-between cursor-pointer group">
@@ -11,9 +61,29 @@
     <div class="text-gray-600 dark:text-gray-300">{recipe.subtitle}</div>
   </div>
   {#if showAdminActions}
-    <div class="flex gap-2">
+    <div class="flex gap-2 items-center">
+      {#if coverage !== undefined}
+        <span class={`text-xs font-semibold ${coverageColor} cursor-pointer`} on:click={openCoverageModal}>{coverage}% Ingredient index</span>
+      {/if}
       <button class="bg-blue-600 hover:bg-blue-700 text-white px-4 py-2 rounded dark:bg-blue-900" on:click={() => dispatch('edit', recipe)}>Rediger Oppskrift ✍️</button>
       <button class="bg-red-600 hover:bg-red-700 text-white px-4 py-2 rounded dark:bg-red-900" on:click={() => dispatch('delete', recipe)}>Slett Oppskrift 🗑️</button>
     </div>
   {/if}
-</div> 
+</div>
+
+<CoverageModal
+  open={showCoverageModal}
+  recipeTitle={recipe.title}
+  missingIngredients={missingIngredients}
+  on:close={closeCoverageModal}
+  on:add={handleCoverageAdd}
+/>
+
+<AddIngredientModal
+  name={addName}
+  ean={addEAN}
+  error={addError}
+  open={showAddModal}
+  on:save={handleAddIngredient}
+  on:close={closeAddModal}
+/>

--- a/src/lib/components/ui/modals/AddIngredientModal.svelte
+++ b/src/lib/components/ui/modals/AddIngredientModal.svelte
@@ -1,0 +1,47 @@
+<script lang="ts">
+  export let name: string = '';
+  export let ean: string = '';
+  export let error: string = '';
+  export let open: boolean = false;
+  import { createEventDispatcher } from 'svelte';
+  const dispatch = createEventDispatcher();
+
+  let localEAN = ean;
+  $: if (open) localEAN = ean;
+
+  function handleSave() {
+    if (!name || !localEAN) {
+      dispatch('save', { name, ean: localEAN, error: 'Navn og EAN er påkrevd' });
+      return;
+    }
+    dispatch('save', { name, ean: localEAN });
+  }
+  function handleClose() {
+    dispatch('close');
+  }
+</script>
+
+{#if open}
+  <div class="fixed inset-0 bg-black bg-opacity-40 flex items-center justify-center z-50">
+    <div class="bg-white dark:bg-gray-800 rounded-lg shadow-lg p-6 w-full max-w-md relative">
+      <h3 class="text-xl font-bold mb-4 dark:text-white">Legg til ingrediens</h3>
+      <form on:submit|preventDefault={handleSave} class="flex flex-col gap-4">
+        <div>
+          <label class="block text-sm font-medium mb-1 dark:text-gray-100">Navn</label>
+          <input class="w-full border rounded p-2 dark:bg-gray-700 dark:text-white" value={name} readonly />
+        </div>
+        <div>
+          <label class="block text-sm font-medium mb-1 dark:text-gray-100">EAN</label>
+          <input class="w-full border rounded p-2 dark:bg-gray-700 dark:text-white" bind:value={localEAN} required />
+        </div>
+        {#if error}
+          <div class="text-red-600 mt-2 dark:text-red-400">{error}</div>
+        {/if}
+        <div class="flex justify-end gap-2 mt-4">
+          <button class="bg-gray-400 text-white px-4 py-2 rounded" type="button" on:click={handleClose}>Avbryt</button>
+          <button class="bg-green-600 text-white px-4 py-2 rounded" type="submit">Lagre</button>
+        </div>
+      </form>
+    </div>
+  </div>
+{/if}

--- a/src/lib/components/ui/modals/AddIngredientModal.svelte
+++ b/src/lib/components/ui/modals/AddIngredientModal.svelte
@@ -4,14 +4,27 @@
   export let error: string = '';
   export let open: boolean = false;
   import { createEventDispatcher } from 'svelte';
+  import { validateEAN } from '$lib/util/validateEAN.js';
   const dispatch = createEventDispatcher();
 
   let localEAN = ean;
-  $: if (open) localEAN = ean;
+  let isBulkItem = false;
+  $: if (open) {
+    localEAN = ean;
+    isBulkItem = false;
+  }
 
   function handleSave() {
+    if (isBulkItem) {
+      dispatch('markBulkItem', { name });
+      return;
+    }
     if (!name || !localEAN) {
       dispatch('save', { name, ean: localEAN, error: 'Navn og EAN er påkrevd' });
+      return;
+    }
+    if (!validateEAN(localEAN)) {
+      dispatch('save', { name, ean: localEAN, error: 'Ugyldig EAN-nummer' });
       return;
     }
     dispatch('save', { name, ean: localEAN });
@@ -32,14 +45,18 @@
         </div>
         <div>
           <label class="block text-sm font-medium mb-1 dark:text-gray-100">EAN</label>
-          <input class="w-full border rounded p-2 dark:bg-gray-700 dark:text-white" bind:value={localEAN} required />
+          <input class="w-full border rounded p-2 dark:bg-gray-700 dark:text-white" bind:value={localEAN} required disabled={isBulkItem} />
+        </div>
+        <div class="flex items-center gap-2">
+          <input id="bulkitem" type="checkbox" bind:checked={isBulkItem} />
+          <label for="bulkitem" class="text-sm dark:text-gray-100">Dette er en bulkvare (skal ikke indekseres)</label>
         </div>
         {#if error}
           <div class="text-red-600 mt-2 dark:text-red-400">{error}</div>
         {/if}
         <div class="flex justify-end gap-2 mt-4">
           <button class="bg-gray-400 text-white px-4 py-2 rounded" type="button" on:click={handleClose}>Avbryt</button>
-          <button class="bg-green-600 text-white px-4 py-2 rounded" type="submit">Lagre</button>
+          <button class="bg-green-600 text-white px-4 py-2 rounded" type="submit">{isBulkItem ? 'Merk som bulkvare' : 'Lagre'}</button>
         </div>
       </form>
     </div>

--- a/src/lib/components/ui/modals/CoverageModal.svelte
+++ b/src/lib/components/ui/modals/CoverageModal.svelte
@@ -1,0 +1,38 @@
+<script lang="ts">
+  export let open: boolean = false;
+  export let recipeTitle: string = '';
+  export let missingIngredients: { name: string }[] = [];
+  import { createEventDispatcher } from 'svelte';
+  const dispatch = createEventDispatcher();
+
+  function handleClose() {
+    dispatch('close');
+  }
+  function handleAdd(name: string) {
+    dispatch('add', { name });
+  }
+</script>
+
+{#if open}
+  <div class="fixed inset-0 bg-black bg-opacity-40 flex items-center justify-center z-50">
+    <div class="bg-white dark:bg-gray-800 rounded-lg shadow-lg p-6 w-full max-w-md relative">
+      <h3 class="text-xl font-bold mb-4 dark:text-white">{recipeTitle}</h3>
+      <div class="mb-2 font-semibold dark:text-gray-100">Mangler i ingrediensindeks:</div>
+      {#if missingIngredients.length === 0}
+        <div class="text-green-600 font-semibold mb-4 dark:text-green-400">Alle ingredienser er indeksert!</div>
+      {:else}
+        <ul class="mb-4">
+          {#each missingIngredients as ing}
+            <li class="flex items-center justify-between mb-2">
+              <span class="dark:text-white">{ing.name}</span>
+              <button class="bg-blue-600 hover:bg-blue-700 text-white px-2 py-1 rounded text-xs" on:click={() => handleAdd(ing.name)}>Legg til</button>
+            </li>
+          {/each}
+        </ul>
+      {/if}
+      <div class="flex justify-end gap-2 mt-4">
+        <button class="bg-gray-400 text-white px-4 py-2 rounded" on:click={handleClose}>Lukk</button>
+      </div>
+    </div>
+  </div>
+{/if} 

--- a/src/lib/components/ui/modals/CoverageModal.svelte
+++ b/src/lib/components/ui/modals/CoverageModal.svelte
@@ -11,6 +11,9 @@
   function handleAdd(name: string) {
     dispatch('add', { name });
   }
+  function handleAddBulk(name: string) {
+    dispatch('addBulk', { name });
+  }
 </script>
 
 {#if open}
@@ -23,9 +26,12 @@
       {:else}
         <ul class="mb-4">
           {#each missingIngredients as ing}
-            <li class="flex items-center justify-between mb-2">
+            <li class="flex items-center justify-between mb-2 gap-2">
               <span class="dark:text-white">{ing.name}</span>
-              <button class="bg-blue-600 hover:bg-blue-700 text-white px-2 py-1 rounded text-xs" on:click={() => handleAdd(ing.name)}>Legg til</button>
+              <div class="flex gap-2">
+                <button class="bg-blue-600 hover:bg-blue-700 text-white px-2 py-1 rounded text-xs" on:click={() => handleAdd(ing.name)}>Legg til</button>
+                <button class="bg-yellow-600 hover:bg-yellow-700 text-white px-2 py-1 rounded text-xs" on:click={() => handleAddBulk(ing.name)}>Marker som bulk</button>
+              </div>
             </li>
           {/each}
         </ul>

--- a/src/lib/util/formatAmount.js
+++ b/src/lib/util/formatAmount.js
@@ -51,4 +51,4 @@ export function formatNumber(amount) {
     }
 
     return formatted;
-} 
+}

--- a/src/lib/util/validateEAN.js
+++ b/src/lib/util/validateEAN.js
@@ -1,0 +1,15 @@
+// Validate EAN-13 barcode
+// Returns true if valid, false otherwise
+export function validateEAN(ean) {
+    // Accept string or number
+    const str = String(ean).trim();
+    if (!/^[0-9]{13}$/.test(str)) return false;
+    // EAN-13 check digit calculation
+    let sum = 0;
+    for (let i = 0; i < 12; i++) {
+        const digit = parseInt(str[i], 10);
+        sum += i % 2 === 0 ? digit : digit * 3;
+    }
+    const check = (10 - (sum % 10)) % 10;
+    return check === parseInt(str[12], 10);
+} 

--- a/src/routes/admin/dashboard/+page.svelte
+++ b/src/routes/admin/dashboard/+page.svelte
@@ -343,6 +343,24 @@
     }
     closeDeleteModal();
   }
+
+  function getCoverage(recipe) {
+    if (!recipe.recipeIngredients || !Array.isArray(recipe.recipeIngredients)) return undefined;
+    const total = recipe.recipeIngredients.length;
+    if (total === 0) return 100;
+    const matched = recipe.recipeIngredients.filter(ri => allIngredients.some(ai => ai.name === ri.name)).length;
+    return Math.trunc((matched / total) * 100);
+  }
+
+  function saveIngredientFromCard({ name, ean, done }) {
+    // Reuse saveIngredient logic, but allow passing name/ean and optionally skip closing modal
+    ingredientForm = { name, ean };
+    ingredientError = '';
+    isEditingIngredient = false;
+    editingIngredient = null;
+    showIngredientModal = true;
+    // Optionally, you can handle 'done' callback if needed
+  }
 </script>
 
 <div class="min-h-screen w-full bg-gray-100 dark:bg-gray-900">
@@ -371,8 +389,11 @@
           <RecipeCard
             {recipe}
             showAdminActions={true}
+            coverage={getCoverage(recipe)}
+            allIngredients={allIngredients}
             on:edit={() => openModal(recipe)}
             on:delete={() => openDeleteModal(recipe, 'recipe')}
+            on:addIngredient={({ detail }) => saveIngredientFromCard(detail)}
           />
         {/each}
       </div>

--- a/src/routes/admin/dashboard/+page.svelte
+++ b/src/routes/admin/dashboard/+page.svelte
@@ -2,6 +2,8 @@
   import { onMount } from 'svelte';
   import toast from 'svelte-french-toast';
   import { nanoid } from 'nanoid';
+  import RecipeCard from '$lib/components/ui/card/RecipeCard.svelte';
+  import IngredientCard from '$lib/components/ui/card/IngredientCard.svelte';
   export let data;
   let recipes = data.recipes;
   let allIngredients = data.ingredients || [];
@@ -343,7 +345,7 @@
   }
 </script>
 
-<div class="flex flex-col items-center w-full dark:bg-gray-900 dark:text-white">
+<div class="min-h-screen w-full bg-gray-100 dark:bg-gray-900">
   <div class="flex items-center w-full max-w-2xl mt-8 mb-4">
     <h2 class="text-2xl font-bold flex-1 dark:text-white">Admin Dashboard</h2>
   </div>
@@ -366,16 +368,12 @@
           </button>
         </div>
         {#each recipes as recipe}
-          <div class="bg-white dark:bg-gray-700 rounded-lg shadow hover:shadow-lg transition-shadow p-4 flex items-center justify-between cursor-pointer group">
-            <div>
-              <div class="font-bold text-lg group-hover:text-blue-700 transition-colors dark:text-white">{recipe.title}</div>
-              <div class="text-gray-600 dark:text-gray-300">{recipe.subtitle}</div>
-            </div>
-            <div class="flex gap-2">
-              <button class="bg-blue-600 hover:bg-blue-700 text-white px-4 py-2 rounded dark:bg-blue-900" on:click={() => openModal(recipe)}>Rediger Oppskrift ✍️</button>
-              <button class="bg-red-600 hover:bg-red-700 text-white px-4 py-2 rounded dark:bg-red-900" on:click={() => openDeleteModal(recipe, 'recipe')}>Slett Oppskrift 🗑️</button>
-            </div>
-          </div>
+          <RecipeCard
+            {recipe}
+            showAdminActions={true}
+            on:edit={() => openModal(recipe)}
+            on:delete={() => openDeleteModal(recipe, 'recipe')}
+          />
         {/each}
       </div>
     {/if}
@@ -401,39 +399,12 @@
           Ingredienser lagt til her vil hente pris og næringsinfo via <a href="https://kassal.app/" target="_blank" rel="noopener noreferrer" class="underline hover:text-blue-700">kassal.app</a>. Data oppdateres hver natt, og vil hentes så lenge EAN-nummeret er korrekt.
         </div>
         {#each allIngredients as ingredient (ingredient._id)}
-          <div class="bg-white dark:bg-gray-700 rounded-lg shadow hover:shadow-lg transition-shadow transition-opacity min-h-[100px] p-4 flex flex-col">
-            <div class="flex items-center justify-between">
-              <div class="font-bold text-lg dark:text-white">{ingredient.name}</div>
-              <div class="flex gap-2">
-                <button class="bg-blue-600 hover:bg-blue-700 text-white px-3 py-1 rounded text-sm dark:bg-blue-900" on:click={() => openEditIngredient(ingredient)}>Rediger ingrediens ✍️</button>
-                <button class="bg-red-600 hover:bg-red-700 text-white px-3 py-1 rounded text-sm dark:bg-red-900" on:click={() => openDeleteModal(ingredient, 'ingredient')}>Slett 🗑️</button>
-              </div>
-            </div>
-            <div class="text-gray-600 dark:text-gray-300 text-sm">
-              EAN: {ingredient.ean || 'N/A'}
-              {#if ingredient.data && ingredient.data.products && ingredient.data.products.length > 0}
-                {#each [ingredient.data.products[0]] as product}
-                  <br />
-                  Pris: {product.current_price?.price ? Number(product.current_price.price).toFixed(2) + ' kr' : 'N/A'}
-                  {#if product.current_price?.unit_price}
-                    &nbsp;|&nbsp; Pris per enhet: {Number(product.current_price.unit_price).toFixed(2)} kr/{product.weight_unit || 'enhet'}
-                  {/if}
-                  {#if product.weight}
-                    &nbsp;|&nbsp; Vekt: {product.weight}{product.weight_unit}
-                  {/if}
-                  {#if product.url}
-                    <br />
-                    <a href={product.url} target="_blank" rel="noopener noreferrer" class="text-blue-600 hover:underline flex items-center gap-1 mt-1">
-                      <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4 inline" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M14 3h7m0 0v7m0-7L10 14m-4 0h7m-7 0v7m0-7L14 3" /></svg>
-                      Produktlink
-                    </a>
-                  {/if}
-                {/each}
-              {:else}
-                <br />Pris: N/A
-              {/if}
-            </div>
-          </div>
+          <IngredientCard
+            {ingredient}
+            showAdminActions={true}
+            on:edit={() => openEditIngredient(ingredient)}
+            on:delete={() => openDeleteModal(ingredient, 'ingredient')}
+          />
         {/each}
       </div>
     {/if}

--- a/src/routes/admin/dashboard/api/recipes/[id]/+server.js
+++ b/src/routes/admin/dashboard/api/recipes/[id]/+server.js
@@ -46,3 +46,55 @@ export async function PUT({ params, request }) {
         return new Response(JSON.stringify({ error: String(e) }), { status: 500 });
     }
 }
+
+export async function PATCH({ params, request }) {
+    const db = await getDatabase();
+    let id = params.id;
+    // Ensure id is a string
+    if (typeof id !== 'string') id = String(id);
+    const patchData = await request.json();
+
+    try {
+        if (patchData.markBulk) {
+            // Mark an ingredient as bulk item
+            const result = await db.collection('recipes').updateOne(
+                {
+                    _id: new ObjectId(id),
+                    'recipeIngredients.name': patchData.markBulk
+                },
+                {
+                    $set: {
+                        'recipeIngredients.$.isBulkItem': true
+                    }
+                }
+            );
+            if (result.matchedCount === 1) {
+                return new Response(JSON.stringify({ success: true }), { status: 200 });
+            } else {
+                return new Response(JSON.stringify({ error: 'Recipe or ingredient not found' }), { status: 404 });
+            }
+        } else if (patchData.updateEAN) {
+            // Update an ingredient's EAN in the recipe
+            const result = await db.collection('recipes').updateOne(
+                {
+                    _id: new ObjectId(id),
+                    'recipeIngredients.name': patchData.updateEAN.name
+                },
+                {
+                    $set: {
+                        'recipeIngredients.$.ean': patchData.updateEAN.ean
+                    }
+                }
+            );
+            if (result.matchedCount === 1) {
+                return new Response(JSON.stringify({ success: true }), { status: 200 });
+            } else {
+                return new Response(JSON.stringify({ error: 'Recipe or ingredient not found' }), { status: 404 });
+            }
+        } else {
+            return new Response(JSON.stringify({ error: 'Invalid patch operation' }), { status: 400 });
+        }
+    } catch (e) {
+        return new Response(JSON.stringify({ error: String(e) }), { status: 500 });
+    }
+}


### PR DESCRIPTION
# ✨ Admin panel feature: Ingredient price coverage per recipe

In order to get live prices, every ingredient needs an EAN number associate with it so that we can fetch the prices from various API's. The admin dashboardh as been built so that it will be easy for an admin to find out what recipes are not 100% covered, as well as be able to add EAN codes per ingredient that is missing one.

## 📸 Screenshots

<img width="2680" height="1320" alt="image" src="https://github.com/user-attachments/assets/d751b16d-e2f2-4bd4-918a-79f65aa57e67" />


## 🧐 Quality Check

Make sure you’ve done the following **before merging** the pull request:

- [ ] Linked this pull request to an issue (if applicable)
- [ ] Written a clear, understandable PR title (even for non-technical readers)
- [ ] Tested the changes included in this PR

> Walk away, take a break, and re-read what you’ve filled out. Would it make sense to someone seeing it for the first time? What extra context could help?
